### PR TITLE
Improve crossword layout responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,18 +1,24 @@
+
+/* Main wrapper styles */
 .app {
   min-height: 100vh;
-  max-width: 100vw;
-  overflow: hidden;
+  width: 100vw;
+  overflow: auto;
   background-color: #2c2c2c;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
+
+/* Crossword grid */
 .crossword {
+  --cell-size: clamp(40px, 8vw, 80px);
+  --gap-size: clamp(10px, 3vw, 30px);
   display: grid;
-  grid-template-columns: repeat(11, 80px);
-  grid-template-rows: repeat(8, 80px);
-  gap: 30px;
+  grid-template-columns: repeat(11, var(--cell-size));
+  grid-template-rows: repeat(8, var(--cell-size));
+  gap: var(--gap-size);
   position: relative;
 }
 
@@ -24,25 +30,25 @@
   justify-content: center;
   align-items: center;
   font-family: 'Averia Serif Libre', serif;
-  font-size: 64px;
+  font-size: calc(var(--cell-size) * 0.8);
   position: relative;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .number {
   position: absolute;
-  top: 4px;
-  left: 4px;
-  font-size: 18px;
+  top: calc(var(--cell-size) * 0.05);
+  left: calc(var(--cell-size) * 0.05);
+  font-size: calc(var(--cell-size) * 0.225);
   font-family: "Arial Rounded MT Bold", "Arial", sans-serif;
   color: #00ff00;
 }
 
 /* Logo styles */
 .logo-wrapper {
-  width: 80px;
-  height: 80px;
-  transform: translateY(0px);
+  width: var(--cell-size);
+  height: var(--cell-size);
+  transform: translateY(0);
 }
 
 .logo {
@@ -55,7 +61,7 @@
 .hover-text {
   position: absolute;
   font-family: Arial, sans-serif;
-  font-size: 24px;
+  font-size: calc(var(--cell-size) * 0.3);
   color: #969696;
   opacity: 0;
   visibility: hidden;
@@ -73,15 +79,15 @@
 }
 
 .lucascorrea-text {
-  top: 420px;
+  top: calc(var(--cell-size) * 5.25);
   left: 0;
-  transform: translateY(10px);
+  transform: translateY(calc(var(--cell-size) * 0.125));
 }
 
 .sobre-text {
-  top: 390px;
-  left: 660px;
-  width: 600px;
+  top: calc(var(--cell-size) * 4.875);
+  left: calc(var(--cell-size) * 8.25);
+  width: calc(var(--cell-size) * 7.5);
   transform: translateY(0);
 }
 
@@ -93,21 +99,21 @@
 }
 
 .projeto-text .about-content {
-  font-size: 16px;
+  font-size: calc(var(--cell-size) * 0.2);
   line-height: 1.6;
 }
 
 .social-links {
-  margin-bottom: 40px;
+  margin-bottom: calc(var(--cell-size) * 0.5);
   text-align: center;
 }
 
 .social-links a {
   color: #969696;
   text-decoration: underline;
-  margin-left: 60px;
-  margin-right: 60px;
-  font-size: 16px;
+  margin-left: calc(var(--cell-size) * 0.75);
+  margin-right: calc(var(--cell-size) * 0.75);
+  font-size: calc(var(--cell-size) * 0.2);
   transition: color 0.3s ease;
 }
 
@@ -127,17 +133,17 @@
 }
 
 .about-content {
-  font-size: 16px;
+  font-size: calc(var(--cell-size) * 0.2);
   line-height: 1.6;
 }
 
 .about-content p {
-  margin-bottom: 20px;
+  margin-bottom: calc(var(--cell-size) * 0.25);
 }
 
 .about-content .experience {
   opacity: 0.8;
-  font-size: 14px;
+  font-size: calc(var(--cell-size) * 0.175);
 }
 
 /* Word hover states */


### PR DESCRIPTION
## Summary
- use CSS variables and clamp to scale crossword cells and gaps with screen size
- position hover text and links with responsive units
- allow page scroll instead of clipping overflowing content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896276c9b14832fabbeee50e51ca5f4